### PR TITLE
Add training data logs and analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # kuhn-poker
+
+This project implements several agents for Kuhn poker, including a simple neural network learner.
+
+## Training the neural network
+
+Run `scripts/train.py` to train the NumPy-based policy network. The script logs statistics every 1000 episodes and saves them to the `Data` directory:
+
+```
+python scripts/train.py
+```
+
+Artifacts written to `Data/`:
+
+- `network_config.json` – hyperparameters of the network used during training
+- `training_history.csv` – snapshot of action counts and rewards every 1000 episodes
+- `learning_curve.png` – plot of average reward over time
+
+## Analysing the training history
+
+To generate additional graphs showing bluff and call rates over time, run:
+
+```
+python scripts/analyze_training.py
+```
+
+This reads `training_history.csv` and saves `strategy_metrics.png` into the same `Data` folder.

--- a/scripts/analyze_training.py
+++ b/scripts/analyze_training.py
@@ -1,0 +1,39 @@
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+
+DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "Data")
+history_file = os.path.join(DATA_DIR, "training_history.csv")
+
+if not os.path.exists(history_file):
+    raise FileNotFoundError(f"{history_file} not found")
+
+history = pd.read_csv(history_file)
+
+# Compute metrics
+history["bluff_rate"] = (
+    history["1_bet"] + history["2_bet"]
+) / (
+    history[[f"{h}_{a}" for h in (1, 2) for a in ("check", "call", "bet", "fold")]].sum(axis=1)
+)
+history["value_bet_rate"] = history["3_bet"] / (
+    history[[f"3_{a}" for a in ("check", "call", "bet", "fold")]].sum(axis=1)
+)
+history["call_rate"] = (
+    history["1_call"] + history["2_call"] + history["3_call"]
+) / (
+    history[[f"{h}_{a}" for h in (1, 2, 3) for a in ("call", "fold")]].sum(axis=1)
+)
+
+plt.figure()
+plt.plot(history["episode"], history["bluff_rate"], label="Bluff rate")
+plt.plot(history["episode"], history["value_bet_rate"], label="Value bet rate")
+plt.plot(history["episode"], history["call_rate"], label="Call rate")
+plt.xlabel("Episode")
+plt.ylabel("Rate")
+plt.title("Strategy Metrics Over Time")
+plt.legend()
+plt.grid(True)
+plt.tight_layout()
+plt.savefig(os.path.join(DATA_DIR, "strategy_metrics.png"))
+


### PR DESCRIPTION
## Summary
- log neural net training stats every 1000 episodes
- save network configuration into `Data/network_config.json`
- write training history to `Data/training_history.csv`
- produce learning curve plot and analysis script
- document training and analysis in README
- refactor action logging using a DataFrame

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c814d45b48331b4a4408829bc8e50